### PR TITLE
remove garbage tabs

### DIFF
--- a/git-xlsx-textconv.go
+++ b/git-xlsx-textconv.go
@@ -23,13 +23,13 @@ func main() {
 	for _, sheet := range xlFile.Sheets {
 		for _, row := range sheet.Rows {
 			cels := make([]string, len(row.Cells))
-			for _, cell := range row.Cells {
+			for i, cell := range row.Cells {
 				s := cell.String()
 				s = strings.Replace(s, "\\", "\\\\", -1)
 				s = strings.Replace(s, "\n", "\\n", -1)
 				s = strings.Replace(s, "\r", "\\r", -1)
 				s = strings.Replace(s, "\t", "\\t", -1)
-				cels = append(cels, s)
+				cels[i] = s
 			}
 			fmt.Printf("[%s] %s\n", sheet.Name, strings.Join(cels, "\t"))
 		}


### PR DESCRIPTION
testfile.xlsx has 2x2 cells, but git-xlsx-textconv outputs 4x2, garbage tabs exists.

```
% git-xlsx-textconv $GOPATH/github.com/tokuhirom/git-xlsx-textconv/testfile.xlsx | cat -A
[Tabelle1] ^I^IFoo^IBar$
[Tabelle1] ^I^IBaz^IQuuk$
```

This commit removes garbage tabs.

```
% go get github.com/minimum2scp/git-xlsx-textconv
% cd $GOPATH/src/github.com/minimum2scp/git-xlsx-textconv
% git checkout -t fix/delete-garbage-tabs
% go run ./git-xlsx-textconv.go ./testfile.xlsx | cat -A
[Tabelle1] Foo^IBar$
[Tabelle1] Baz^IQuuk$
```
