### PR TITLE
update in the installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ git diff wrapper for xlsx file.
 <img src="http://t.co/5Epi6NXHZ5">
 
 # install
-
-    $ go get github.com/tokuhirom/git-xlsx-textconv
+* Go 1.17 or older  
+`$ go get github.com/tokuhirom/git-xlsx-textconv`
+* Go 1.18 or later  
+`$ go get github.com/tokuhirom/git-xlsx-textconv@latest`
     
 # .gitconfig
 


### PR DESCRIPTION
Hello. Thanks for your useful tool.

I found that the install command `$ go get github.com/tokuhirom/git-xlsx-textconv` in README.md is no longer working in the latest Golang and I got a bit confused (because I'm new to golang).  

Instead of that, the command `$ go get github.com/tokuhirom/git-xlsx-textconv@latest` worked on my environment, so I wrote about this to README.

Hope this helps.